### PR TITLE
Additional checks added for source and target clusters

### DIFF
--- a/cluster-health-checks.md
+++ b/cluster-health-checks.md
@@ -19,6 +19,10 @@ This list is not comprehensive and the verification of these checks does not gua
 
 You can perform the following health checks on an OpenShift 3.9+ source cluster:
 
+* Check that the Openshift [version is supported](https://docs.openshift.com/container-platform/4.5/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-prerequisites_migrating-3-4) by the migration tool. 
+
+* Verify that all nodes in the OpenShift cluster contain an active OpenShift Container Platform subscription. This will avoid issues in case support needs to be contacted. 
+
 * Install and configure [Prometheus cluster monitoring](https://docs.openshift.com/container-platform/3.11/install_config/prometheus_cluster_monitoring.html). Prometheus provides a detailed view of the health of the cluster components.
 
 * Check the node status to verify that all nodes are in a **Ready** state: 
@@ -55,6 +59,16 @@ You can perform the following health checks on an OpenShift 3.9+ source cluster:
   $ oc get crs
   ```
 
+* Check that [time synchronization](https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-ntp-synchronization) is consistent across the whole cluster.
+
+* Check that the internal container image registry is healthy, images can be read from and written to it.
+
+* Check that the internal container image registry uses a [supported storage type.](https://docs.openshift.com/container-platform/3.11/scaling_performance/optimizing_storage.html#registry)
+
+* Check that applications are not using [eprecated Kubernetes API references](https://docs.openshift.com/container-platform/4.5/migration/migrating_3_4/troubleshooting-3-4.html#migration-gvk-incompatibility_migrating-3-4).  The migration tool will warn you about any resources using deprecated Kubernetes API references. 
+
+* Check that all nodes in the cluster have high [entropy value](https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-entropy).
+
 ### Target cluster
 
 You can perform the following health checks on an OpenShift 4.x target cluster:
@@ -77,6 +91,8 @@ You can perform the following health checks on an OpenShift 4.x target cluster:
 
 * Check that the OpenShift 4.x target cluster meets the minimum hardware requirements for the specific platform and installation method. For example, a bare metal installation has [specific minimum resource requirements](https://docs.openshift.com/container-platform/4.5/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal).
 
+* Verify that the OpenShift 4.x target cluster contains storage classes for the same types (block, file, object) as the Openshift 3.9+ source cluster.  In particular verify that the default storage class is of the same type in both clusters.
+
 * Check the available bandwidth between the source and target clusters. Less than 10 Gbps is not recommended.
 
 * If you are migrating more than 20 TB, check that the target cluster and the replication repository have sufficient storage.
@@ -92,3 +108,5 @@ You can perform the following health checks on an OpenShift 4.x target cluster:
 * Review the [migration considerations](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/migration/index#migration-considerations).
 
 * Check that the identity provider is working on the source and target clusters.
+
+* Verify that the network visibility between namespaces in the OpenShift 4.x target cluster is as expected, especially if the OpenShift 3.9+ source cluster uses the [**multitenant** network plugin](https://docs.openshift.com/container-platform/3.11/architecture/networking/sdn.html#architecture-additional-concepts-sdn).  Openshift 4.x uses the [**networkpolicy** network plugin](https://docs.openshift.com/container-platform/4.5/networking/network_policy/about-network-policy.html) with an open policy by default in which all pods and services are accessible from any project.


### PR DESCRIPTION
- Openshift version
- OCP valid subscriptions
- NTP synchronization
- Container image registry
- Deprecated Kubernetes APIs
- Entropy
- Storage classes
- Network plugins.  multitenant vs networkpolicy

Signed-off-by: Jose Ignacio Jerez Rodriguez <jjerezro@redhat.com>

+* Verify that the OpenShift 4.x target cluster contains storage classes for the same types (block, file, object) as the Openshift 3.9+ source cluster.  In particular verify that the default storage class is of the same type in both clusters.
+
 * Check the available bandwidth between the source and target clusters. Less than 10 Gbps is not recommended.

 * If you are migrating more than 20 TB, check that the target cluster and the replication repository have sufficient storage.
@@ -92,3 +108,5 @@ You can perform the following health checks on an OpenShift 4.x target cluster:
 * Review the [migration considerations](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html-single/migration/index#migration-considerations).

 * Check that the identity provider is working on the source and target clusters.
+
+* Verify that the network visibility between namespaces in the OpenShift 4.x target cluster is as expected, especially if the OpenShift 3.9+ source cluster uses the [**multitenant** network plugin](https://docs.openshift.com/container-platform/3.11/architecture/networking/sdn.html#architecture-additional-concepts-sdn).  Openshift 4.x uses the [**networkpolicy** network plugin](https://docs.openshift.com/container-platform/4.5/networking/network_policy/about-network-policy.html) with an open policy by default in which all pods and services are accessible from any project.