### PR TITLE
Migration environment considerations: new bullet point `OpenShift 4 Feature Gaps with OCP 3.11`

### DIFF
--- a/planning.md
+++ b/planning.md
@@ -111,6 +111,7 @@ The migration workflow is similar to the following procedure:
 
 This section describes migration environment considerations to consider when you are planning your migration:
 
+* Consider the OpenShift 4 feature gaps with OCP 3.11
 * Consider how stored data will be migrated if you are migrating stateful applications.
 * Consider how much downtime your application can tolerate during migration.
 * Plan for traffic redirection during migration.


### PR DESCRIPTION
I think it's key to consider if the __new environment__ offers you the same key features as your __current environment__.

There is a shared internal document where you can see all of those features gaps between the both OpenShift mayor versions [1].

An example of what I mean is the customizability of the OpenShift Ingress (routers): until OpenShift 4.5, something as common as let the client be able to send the routers access logs to his observability stack it was not possible. In some clients / cases this is a business impact as they have Government/Law requirements related to the management of the access logs.

[1] [OpenShift 4 Feature Gaps with OCP 3.11](https://docs.google.com/spreadsheets/d/1l5xb_kffXWMLIW5DSA2TckQHCGYB8Q-WOAeSh9TZsNw/edit#gid=0)