### PR TITLE
Adding further detail on where data captured by the must-gather lands

### DIFF
--- a/troubleshooting.md
+++ b/troubleshooting.md
@@ -140,6 +140,8 @@ Run the `must-gather` command on your cluster:
 $ oc adm must-gather --image=openshift-migration-must-gather-rhel8:v1.3.0
 ````
 
+A directory will be created which will contain the data collected by the `must-gather` tool.
+
 ## Previewing metrics on local Prometheus server
 
 You can use `must-gather` to create a metrics data directory dump from the last day:


### PR DESCRIPTION
There is sometimes confusion on how must-gather captures data.  On a number of occasions customers will send back the text output as opposed to the contents of the generated directory.