### PR TITLE
Tune page build to use branch 'main' instead of 'master'

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -3,7 +3,7 @@ name: Deploy via Jekyll on GitHub  pages
 on:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron:  '0 0 * * *'
 


### PR DESCRIPTION
Tune branch to build from


Once merged, Repo settings should use the generated `gh-pages` branch for serving as web content

Additionally, repo info in main page can point to the rendered URL:

https://redhat-cop.github.io/openshift-migration-best-practices/ 

Similar to:
![image](https://user-images.githubusercontent.com/312463/99550723-506ee480-29bb-11eb-9438-7b3a8c1dfed1.png)
