### PR TITLE
Set baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 theme: jekyll-rtd-theme
 title: OpenShift Migration Best Practices
 repo_url: 'https://github.com/redhat-cop/openshift-migration-best-practices'
+baseurl: '/openshift-migration-best-practices/'
 
 plugins:
   - jekyll-paginate


### PR DESCRIPTION
Sets base url for links to remain in 'openshift-migration-best-practices' repo