### PR TITLE
Fixed dead links and repoint them to the latest version of MTC

### DIFF
--- a/01-planning.md
+++ b/01-planning.md
@@ -48,9 +48,10 @@ If you can redeploy your application from pipeline, that is the best option. If 
 
 #### MTC documentation
 
-- [Prerequisites](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-prerequisites_migrating-3-4)
-- [About MTC](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-understanding-cam_migrating-3-4)
-- [About data copy methods](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-understanding-data-copy-methods_migrating-3-4)
+- [Prerequisites](https://access.redhat.com/articles/5064151)
+- [About MTC on OpenShift 3](https://access.redhat.com/articles/5064151#installing-the-mtc-with-the-web-console-and-the-migration-controller-on-a-4x-remote-cluster-2)
+- [About MTC on OpenShift 4](https://docs.openshift.com/container-platform/4.6/migration-toolkit-for-containers/installing-mtc.html)
+- [About data copy methods](https://docs.openshift.com/container-platform/4.6/migration-toolkit-for-containers/about-mtc.html#migration-understanding-data-copy-methods_about-mtc)
 
 ## Migration environment considerations
 

--- a/03-pre-migration-testing.md
+++ b/03-pre-migration-testing.md
@@ -9,9 +9,10 @@ layout: default
 
 Install MTC on your source and target clusters:
 
-- Check the [migration prerequisites](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-prerequisites_migrating-3-4).
-- [Install MTC](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/deploying-cam-3-4.html) on the source and target clusters.
-- [Configure a replication repository](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/configuring-replication-repository-3-4.html).
+- [Prerequisites](https://access.redhat.com/articles/5064151)
+- [About MTC on OpenShift 3](https://access.redhat.com/articles/5064151#installing-the-mtc-with-the-web-console-and-the-migration-controller-on-a-4x-remote-cluster-2)
+- [About MTC on OpenShift 4](https://docs.openshift.com/container-platform/4.6/migration-toolkit-for-containers/installing-mtc.html)
+- [About data copy methods](https://docs.openshift.com/container-platform/4.6/migration-toolkit-for-containers/about-mtc.html#migration-understanding-data-copy-methods_about-mtc)
 
 The following diagram describes how MTC uses Velero and Restic to back up data from the source cluster to the replication repository and then restores data from the replication repository to the target cluster:
 
@@ -43,7 +44,7 @@ In the web console, check the 'OLM Managed' setting in the 'MigrationController'
 Migrate a simple application without a persistent volume (PV):
 
 1. Install a simple application without a PV on the source cluster.
-2. [Migrate the application](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-applications-with-cam-3-4.html) to the target cluster. You do not need to stage the migration.
+2. [Migrate the application](https://docs.openshift.com/container-platform/4.4/migration/migrating_3_4/about-migration.html) to the target cluster. You do not need to stage the migration.
 3. Validate the application on the target cluster.
 
 ## Migrating an application with a persistent volume

--- a/04-running-the-migration.md
+++ b/04-running-the-migration.md
@@ -25,9 +25,9 @@ Prepare your migration environment by checking the following:
   - Check whether your application uses a service network or an external route to communicate with services.
   - If your application uses non-namespaced resources, you must re-create them on the target cluster.
   - You must migrate images from the internal image registry if you are not using an external image registry. If they cannot be migrated, you must re-create them manually on the target cluster.
-  - Increase the [CPU and memory limits of the Migration Controller](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-applications-with-cam-3-4.html#migration-changing-migration-plan-limits_migrating-3-4) for large migrations.
+  - Check the prerequisites [MTC configuration](https://docs.openshift.com/container-platform/4.7/migration-toolkit-for-containers/migrating-applications-with-mtc.html) for the migration, do increase CPU and memory allocation for large migrations.
   - Use the [`prune` command](https://docs.openshift.com/container-platform/4.7/applications/pruning-objects.html) to remove old builds, deployments, and images from each namespace being migrated.
-  - [Exclude PVs, image streams, and other resources](https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-applications-with-cam-3-4.html#migration-excluding-resources_migrating-3-4) if you do not want to migrate them with MTC.
+  - [Exclude PVs, image streams, and other resources from the migration plan](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/migration_toolkit_for_containers/migrating-from-openshift-container-platform-3#configuring-migration-plan_migrating-3-4) if you do not want to migrate them with MTC.
 - Namespaces:
   - Check the namespaces on the target cluster to ensure that they do not duplicate namespaces being migrated.
   - Do not create namespaces for your application on the target cluster before migration because this can cause quotas to change.

--- a/05-troubleshooting.md
+++ b/05-troubleshooting.md
@@ -462,7 +462,7 @@ The following procedure removes the MTC Operator and cluster-scoped resources:
 
 2. Uninstall the MTC Operator:
 
-   - OpenShift 4: Uninstall the Operator in the [web console](https://docs.openshift.com/container-platform/4.7/operators/olm-deleting-operators-from-cluster.html) or by running the following command:
+   - OpenShift 4: Uninstall the Operator in the [web console](https://docs.openshift.com/container-platform/4.6/operators/olm-deleting-operators-from-cluster.html) or by running the following command:
 
    ```sh
    $ oc delete ns openshift-migration

--- a/06-post-migration-considerations.md
+++ b/06-post-migration-considerations.md
@@ -73,6 +73,6 @@ You can learn more about how to create your own operators in the [Building Opera
 You can continue learning about operators in the following resources:
 
 - [OpenShift 4 Operators Documentation](https://docs.openshift.com/container-platform/4.7/operators/understanding/olm-what-operators-are.html)
-- [OpenShift 4 Getting started with the Operator SDK](https://docs.openshift.com/container-platform/4.7/operators/operator_sdk/osdk-getting-started.html)
+- [OpenShift 4 Getting started with the Operator SDK](https://docs.openshift.com/container-platform/4.6/operators/operator_sdk/osdk-getting-started.html)
 - [OpenShift Learn Operators](https://www.openshift.com/learn/topics/operators)
 - [Operator SDK Documentation](https://sdk.operatorframework.io/)


### PR DESCRIPTION
Some fixes for dead links and some are pointed to the 4.6 branch of OpenShift as the 4.7 docs did not exist and no clear deprecation flag was set for these. 